### PR TITLE
fix(main): use DEFAULT_SESSION_NAME for main session initialization

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -52,7 +52,7 @@ async def lifespan(app: FastAPI):
     logger.info("--- Starting application lifespan ---")
     
     # We only need one client instance for both listening and joining
-    main_session_name = "bini"
+    main_session_name = settings.DEFAULT_SESSION_NAME
     client = get_telethon_client(main_session_name)
     
     logger.info(f"Connecting main client for '{main_session_name}'...")


### PR DESCRIPTION
This pull request makes a small configuration improvement by replacing the hardcoded session name with a configurable setting. This increases flexibility and makes the codebase easier to maintain.

- Configuration improvement:
  * Replaced the hardcoded `main_session_name` value `"bini"` with `settings.DEFAULT_SESSION_NAME` in the `lifespan` function of `main.py`, allowing session names to be configured through settings.